### PR TITLE
fix: Check for null before checking `method_exists` on reflector

### DIFF
--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -60,7 +60,7 @@ class AugmentParameters implements GeneratorAwareInterface
         foreach ($parameters as $parameter) {
             $context = $parameter->_context;
 
-            if (Generator::isDefault($parameter->name) && method_exists($context->reflector, 'getName')) {
+            if (Generator::isDefault($parameter->name) && null !== $context->reflector && method_exists($context->reflector, 'getName')) {
                 $parameter->name = $context->reflector->getName();
             }
 


### PR DESCRIPTION
`null` is not being checked here, which is causing a `TypeError`

https://github.com/nelmio/NelmioApiDocBundle/pull/2588#issuecomment-3510304087

```
TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given

/Volumes/sourceCode/github/NelmioApiDocBundle/vendor/zircote/swagger-php/src/Processors/AugmentParameters.php:63
/Volumes/sourceCode/github/NelmioApiDocBundle/vendor/zircote/swagger-php/src/Processors/AugmentParameters.php:49
/Volumes/sourceCode/github/NelmioApiDocBundle/vendor/zircote/swagger-php/src/Pipeline.php:113
/Volumes/sourceCode/github/NelmioApiDocBundle/src/ApiDocGenerator.php:136
/Volumes/sourceCode/github/NelmioApiDocBundle/tests/Functional/WebTestCase.php:31
/Volumes/sourceCode/github/NelmioApiDocBundle/tests/Functional/WebTestCase.php:44
/Volumes/sourceCode/github/NelmioApiDocBundle/tests/Functional/ValidationGroupsFunctionalTest.php:56
```