### PR TITLE
feat: add Assembler and AttributeFactory for spec attribute collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Tools
+
+All tools are run via composer:
+
+- `composer lint` — check all code style issues (cs-fixer + rector)
+- `composer cs` / `composer rector` — fix code style issues
+- `composer analyse` — static analysis (phpstan)
+- `composer test` — lint + unit tests; use `./bin/phpunit` directly to run only tests (e.g. `./bin/phpunit --filter ClassName`)
+- `composer redocly` — validate spec fixtures (currently failing, fixtures not yet valid)
+
+# Tests
+
+- Prefer compact tests and data providers over repetition
+- Use shared traits from `tests/Concerns/` for common helpers (e.g. `AssemblesSpecification`)

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Utils\AttributeFactory;
+
+/**
+ * Collects OpenAPI spec attributes from PHP reflectors and assembles them into a Specification.
+ *
+ * The assembler operates in two passes:
+ *
+ * 1. Stack-resolve (resolveNesting): On each reflector, sibling attributes are merged
+ *    using merge() — e.g., a Schema adjacent to a Property on the same parameter
+ *    fills the Property's $schema slot.
+ *
+ * 2. Hierarchical absorb (resolveHierarchy): Attributes from inner reflectors (properties,
+ *    parameters, constants) flow up into enclosing-level containers using contains() —
+ *    e.g., Property instances from class members are absorbed into the class-level Schema.
+ *
+ * After both passes, only root attributes (isRoot() = true) should remain.
+ */
+class Assembler
+{
+    public function __construct(
+        protected Specification $specification = new Specification(),
+        protected AttributeFactory $factory = new AttributeFactory(),
+    ) {
+    }
+
+    public function getSpecification(): Specification
+    {
+        return $this->specification;
+    }
+
+    public function getFactory(): AttributeFactory
+    {
+        return $this->factory;
+    }
+
+    /**
+     * Collect all OpenAPI attributes from the given reflectors into the specification.
+     */
+    public function collect(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors): static
+    {
+        foreach ($reflectors as $reflector) {
+            $this->collectFromReflector($reflector);
+        }
+
+        return $this;
+    }
+
+    protected function collectFromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): void
+    {
+        if ($reflector instanceof \ReflectionClass) {
+            $this->collectFromClass($reflector);
+
+            return;
+        }
+
+        foreach ($this->factory->fromReflector($reflector) as $root) {
+            $this->specification->add($root);
+        }
+    }
+
+    /**
+     * Collect attributes from a class: stack-resolve at each structural level,
+     * then hierarchically absorb inner attributes into class-level containers.
+     */
+    protected function collectFromClass(\ReflectionClass $class): void
+    {
+        $outer = $this->factory->fromReflector($class);
+
+        if ($outer !== []) {
+            // Only collect own members when the class has a root attribute (e.g. Schema).
+            // Classes without root attributes (plain parents/traits) are handled later
+            // by ExpandHierarchy which merges their members into the child schema.
+            $inner = $this->factory->membersOf($class);
+            $roots = $this->factory->resolveHierarchy($outer, $inner);
+
+            foreach ($roots as $root) {
+                $this->specification->add($root);
+            }
+        }
+
+        // Methods are always processed — a controller may have operations without
+        // any class-level schema attribute. Properties on methods are handled via
+        // membersOf() (absorbed into class schema) or ExpandHierarchy (non-schema interfaces).
+        foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            if ($this->factory->hasOnlyProperties($method)) {
+                continue;
+            }
+            foreach ($this->factory->fromReflector($method) as $root) {
+                $this->specification->add($root);
+            }
+        }
+    }
+}

--- a/src/AttributeInterface.php
+++ b/src/AttributeInterface.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Utils\SourceLocation;
+
+/**
+ * Contract for all OpenAPI spec attributes.
+ *
+ * The assembler uses three metadata methods to determine how attributes
+ * relate to each other:
+ *
+ * - isRoot(): root attributes are top-level elements that end up in the Specification
+ *   (Schema, Operation, Info, etc.). Non-root attributes must be absorbed by a container.
+ *
+ * - merge(): defines same-reflector composition. When two attributes sit on the
+ *   same PHP reflector (property, parameter, method), merge() declares which sibling
+ *   types this attribute can be nested into. E.g., Schema merges into Property,
+ *   filling its $schema slot.
+ *
+ * - contains(): defines hierarchical absorption. Attributes from inner reflectors
+ *   flow up into enclosing-level attributes. contains() declares which types a
+ *   container can absorb from the level below. E.g., Operation on a method contains
+ *   RequestBody from a parameter; Schema on a class contains Property from members.
+ */
+interface AttributeInterface
+{
+    /**
+     * Whether this attribute is a root-level element that goes directly into the Specification.
+     */
+    public function isRoot(): bool;
+
+    /**
+     * Sibling types this attribute can merge into on the same reflector.
+     *
+     * When multiple attributes are declared on the same PHP element, merge() determines
+     * which sibling absorbs this attribute. Keys are the target class, values are the
+     * property name on the target where this attribute will be placed.
+     *
+     * Use '[]' suffix for collection slots (append): 'parameters[]'
+     * Omit suffix for scalar slots (set): 'schema'
+     *
+     * Return an empty array if this attribute never merges into siblings.
+     *
+     * @return array<class-string<AttributeInterface>, string>
+     */
+    public function merge(): array;
+
+    /**
+     * Types this attribute can absorb from inner reflector levels.
+     *
+     * During hierarchical resolution (class absorbs members, method absorbs parameters),
+     * the assembler uses contains() to determine which inner-level attributes flow into
+     * this container. Keys are the child class, values are the property name on this
+     * attribute where the child will be placed.
+     *
+     * Use '[]' suffix for collection slots (append): 'properties[]'
+     * Omit suffix for scalar slots (set): 'requestBody'
+     *
+     * Return an empty array if this attribute does not absorb children.
+     *
+     * @return array<class-string<AttributeInterface>, string>
+     */
+    public function contains(): array;
+
+    public function getReflector(): ?\Reflector;
+
+    public function setReflector(?\Reflector $reflector): static;
+
+    public function getClassReflector(): ?\ReflectionClass;
+
+    public function getClassName(): ?string;
+
+    public function getShortClassName(): ?string;
+
+    public function getSourceLocation(): SourceLocation;
+}

--- a/src/OpenApiException.php
+++ b/src/OpenApiException.php
@@ -6,6 +6,22 @@
 
 namespace OpenApi;
 
+use OpenApi\Utils\SourceLocation;
+
 class OpenApiException extends \Exception
 {
+    protected ?SourceLocation $sourceLocation = null;
+
+    public static function fromSource(string $message, SourceLocation $sourceLocation, ?\Throwable $previous = null): self
+    {
+        $exception = new self("{$message} at {$sourceLocation}", 0, $previous);
+        $exception->sourceLocation = $sourceLocation;
+
+        return $exception;
+    }
+
+    public function getSourceLocation(): ?SourceLocation
+    {
+        return $this->sourceLocation;
+    }
 }

--- a/src/Spec/AbstractAttribute.php
+++ b/src/Spec/AbstractAttribute.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+use OpenApi\AttributeInterface;
+use OpenApi\Utils\SourceLocation;
+
+abstract class AbstractAttribute implements AttributeInterface
+{
+    protected ?\Reflector $reflector = null;
+
+    protected ?SourceLocation $sourceLocation = null;
+
+    /**
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        public ?array $x = null,
+    ) {
+    }
+
+    public function isRoot(): bool
+    {
+        return false;
+    }
+
+    public function merge(): array
+    {
+        return [];
+    }
+
+    public function contains(): array
+    {
+        return [];
+    }
+
+    public function getReflector(): ?\Reflector
+    {
+        return $this->reflector;
+    }
+
+    public function getClassReflector(): ?\ReflectionClass
+    {
+        $reflector = $this->reflector;
+
+        if ($reflector instanceof \ReflectionClass) {
+            return $reflector;
+        }
+
+        if ($reflector instanceof \ReflectionMethod || $reflector instanceof \ReflectionProperty || $reflector instanceof \ReflectionClassConstant) {
+            return $reflector->getDeclaringClass();
+        }
+
+        if ($reflector instanceof \ReflectionParameter) {
+            $function = $reflector->getDeclaringFunction();
+
+            return $function instanceof \ReflectionMethod ? $function->getDeclaringClass() : null;
+        }
+
+        return null;
+    }
+
+    public function getClassName(): ?string
+    {
+        return $this->getClassReflector()?->getName();
+    }
+
+    public function getShortClassName(): ?string
+    {
+        return $this->getClassReflector()?->getShortName();
+    }
+
+    public function setReflector(?\Reflector $reflector): static
+    {
+        $this->reflector = $reflector;
+        $this->sourceLocation = null;
+
+        return $this;
+    }
+
+    public function getSourceLocation(): SourceLocation
+    {
+        if (!$this->sourceLocation instanceof SourceLocation) {
+            $this->sourceLocation = $this->reflector instanceof \Reflector
+                ? SourceLocation::fromReflector($this->reflector)
+                : new SourceLocation();
+        }
+
+        return $this->sourceLocation;
+    }
+}

--- a/src/Spec/Components.php
+++ b/src/Spec/Components.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Container for reusable component definitions.
+ *
+ * Place on a class to declare standalone components that go into the components section
+ * of the OpenAPI document. The Components attribute itself is not emitted — its children
+ * are promoted to their respective Specification buckets.
+ *
+ * The primary use case is for DTOs that are NOT roots and therefore cannot be declared
+ * at class level on their own: Parameter, Header, Link, and Example. Other types
+ * (Schema, PathItem, SecurityScheme, named Response/RequestBody) are already roots and
+ * can be declared directly on a class without needing a Components wrapper.
+ *
+ *   #[Components]
+ *   class SharedComponents {
+ *       #[Parameter(parameter: 'tenant_id', name: 'tenant_id', in: 'path', schema: new Schema(type: 'string'))]
+ *       public string $tenantId;
+ *
+ *       #[Header(header: 'X-Rate-Limit', schema: new Schema(type: 'integer'))]
+ *       public string $rateLimit;
+ *
+ *       #[Example(example: 'dog', summary: 'A dog', value: ['name' => 'Fido'])]
+ *       public string $dogExample;
+ *   }
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Components extends AbstractAttribute
+{
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [
+            Schema::class => 'schemas[]',
+            Parameter::class => 'parameters[]',
+            Response::class => 'responses[]',
+            RequestBody::class => 'requestBodies[]',
+            Header::class => 'headers[]',
+            Security\Scheme::class => 'securitySchemes[]',
+            Link::class => 'links[]',
+            Example::class => 'examples[]',
+            PathItem::class => 'pathItems[]',
+        ];
+    }
+
+    /** @var list<Schema> */
+    public array $schemas = [];
+
+    /** @var list<Parameter> */
+    public array $parameters = [];
+
+    /** @var list<Response> */
+    public array $responses = [];
+
+    /** @var list<RequestBody> */
+    public array $requestBodies = [];
+
+    /** @var list<Header> */
+    public array $headers = [];
+
+    /** @var list<Security\Scheme> */
+    public array $securitySchemes = [];
+
+    /** @var list<Link> */
+    public array $links = [];
+
+    /** @var list<Example> */
+    public array $examples = [];
+
+    /** @var list<PathItem> */
+    public array $pathItems = [];
+}

--- a/src/Spec/Contact.php
+++ b/src/Spec/Contact.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Contact information for the exposed API.
+ *
+ * @see [Contact Object](https://spec.openapis.org/oas/v3.1.1.html#contact-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Contact extends AbstractAttribute
+{
+    /**
+     * @param string|null              $name  The identifying name of the contact person/organization
+     * @param string|null              $url   A URL pointing to the contact information
+     * @param string|null              $email The email address of the contact person/organization
+     * @param array<string,mixed>|null $x     Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $url = null,
+        public ?string $email = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Info::class => 'contact'];
+    }
+}

--- a/src/Spec/Discriminator.php
+++ b/src/Spec/Discriminator.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Aids in serialization, deserialization, and validation when request bodies or responses
+ * can be one of several schemas (used with oneOf, anyOf, allOf).
+ *
+ * @see [Discriminator Object](https://spec.openapis.org/oas/v3.1.1.html#discriminator-object)
+ */
+#[\Attribute]
+class Discriminator extends AbstractAttribute
+{
+    /**
+     * @param string|null               $propertyName The name of the property in the payload that distinguishes types
+     * @param array<string,string>|null $mapping      Maps payload values to schema names or references
+     * @param array<string,mixed>|null  $x            Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $propertyName = null,
+        public ?array $mapping = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Schema::class => 'discriminator'];
+    }
+}

--- a/src/Spec/Encoding.php
+++ b/src/Spec/Encoding.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes the encoding for a single property in a media type.
+ *
+ * @see [Encoding Object](https://spec.openapis.org/oas/v3.1.1.html#encoding-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Encoding extends AbstractAttribute
+{
+    /**
+     * @param string|null              $encoding      The property name this encoding applies to
+     * @param string|null              $contentType   The Content-Type for encoding a specific property
+     * @param list<Header>|null        $headers       Additional headers for multipart media types
+     * @param string|null              $style         How the property value is serialized
+     * @param bool|null                $explode       Whether arrays/objects generate separate parameters
+     * @param bool|null                $allowReserved Whether reserved characters are allowed without encoding
+     * @param array<string,mixed>|null $x             Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $encoding = null,
+        public ?string $contentType = null,
+        public ?array $headers = null,
+        public ?string $style = null,
+        public ?bool $explode = null,
+        public ?bool $allowReserved = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [MediaType::class => 'encoding[]'];
+    }
+}

--- a/src/Spec/Example.php
+++ b/src/Spec/Example.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes an example value for a parameter, media type, or schema.
+ *
+ * @see [Example Object](https://spec.openapis.org/oas/v3.1.1.html#example-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Example extends AbstractAttribute
+{
+    /**
+     * @param string|null              $example       Reusable example identifier (component key)
+     * @param string|null              $summary       Short description of the example
+     * @param string|null              $description   Long description of the example (CommonMark syntax)
+     * @param mixed                    $value         Embedded literal example value
+     * @param string|null              $externalValue A URI pointing to the literal example
+     * @param string|null              $ref           A JSON Reference to a reusable example
+     * @param array<string,mixed>|null $x             Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $example = null,
+        public ?string $summary = null,
+        public ?string $description = null,
+        public mixed $value = null,
+        public ?string $externalValue = null,
+        public ?string $ref = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [
+            MediaType::class => 'examples[]',
+            Parameter::class => 'examples[]',
+            Header::class => 'examples[]',
+        ];
+    }
+}

--- a/src/Spec/ExternalDocumentation.php
+++ b/src/Spec/ExternalDocumentation.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Allows referencing an external resource for extended documentation.
+ *
+ * @see [External Documentation Object](https://spec.openapis.org/oas/v3.1.1.html#external-documentation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class ExternalDocumentation extends AbstractAttribute
+{
+    /**
+     * @param string|null              $url         The URL for the target documentation
+     * @param string|null              $description A description of the target documentation (CommonMark syntax)
+     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $url = null,
+        public ?string $description = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+}

--- a/src/Spec/ExternalDocumentation.php
+++ b/src/Spec/ExternalDocumentation.php
@@ -31,4 +31,12 @@ class ExternalDocumentation extends AbstractAttribute
     {
         return true;
     }
+
+    public function merge(): array
+    {
+        return [
+            Operation::class => 'externalDocs',
+            Schema::class => 'externalDocs',
+        ];
+    }
 }

--- a/src/Spec/Flow.php
+++ b/src/Spec/Flow.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Configuration details for a supported OAuth2 flow.
+ *
+ * Typed subtypes pre-fill the flow type:
+ * - `OA\Flow\Implicit` - implicit grant (authorizationUrl required)
+ * - `OA\Flow\Password` - resource owner password credentials (tokenUrl required)
+ * - `OA\Flow\ClientCredentials` - client credentials grant (tokenUrl required)
+ * - `OA\Flow\AuthorizationCode` - authorization code grant (authorizationUrl + tokenUrl required)
+ *
+ *   #[OA\Security\Scheme\OAuth2(securityScheme: 'oauth2', flows: [
+ *       new OA\Flow\AuthorizationCode(
+ *           authorizationUrl: 'https://example.com/oauth/authorize',
+ *           tokenUrl: 'https://example.com/oauth/token',
+ *           scopes: ['read:pets' => 'Read pets', 'write:pets' => 'Write pets'],
+ *       ),
+ *   ])]
+ *
+ * Produces:
+ *   components:
+ *     securitySchemes:
+ *       oauth2:
+ *         type: oauth2
+ *         flows:
+ *           authorizationCode:
+ *             authorizationUrl: https://example.com/oauth/authorize
+ *             tokenUrl: https://example.com/oauth/token
+ *             scopes:
+ *               read:pets: Read pets
+ *               write:pets: Write pets
+ *
+ * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
+ * @see [OAuth Flows Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flows-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Flow extends AbstractAttribute
+{
+    /**
+     * @param string|null               $flow             The OAuth2 flow type (implicit, password, clientCredentials, authorizationCode)
+     * @param string|null               $authorizationUrl The authorization URL for this flow
+     * @param string|null               $tokenUrl         The token URL for this flow
+     * @param string|null               $refreshUrl       The URL for obtaining refresh tokens
+     * @param array<string,string>|null $scopes           The available scopes for the OAuth2 security scheme
+     * @param array<string,mixed>|null  $x                Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $flow = null,
+        public ?string $authorizationUrl = null,
+        public ?string $tokenUrl = null,
+        public ?string $refreshUrl = null,
+        public ?array $scopes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Security\Scheme::class => 'flows[]'];
+    }
+}

--- a/src/Spec/Flow/AuthorizationCode.php
+++ b/src/Spec/Flow/AuthorizationCode.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Flow;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Configuration for the OAuth2 Authorization Code flow.
+ *
+ * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class AuthorizationCode extends OA\Flow
+{
+    /**
+     * @param array<string,string>|null $scopes
+     * @param array<string,mixed>|null  $x
+     */
+    public function __construct(
+        ?string $authorizationUrl = null,
+        ?string $tokenUrl = null,
+        ?string $refreshUrl = null,
+        ?array $scopes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            flow: 'authorizationCode',
+            authorizationUrl: $authorizationUrl,
+            tokenUrl: $tokenUrl,
+            refreshUrl: $refreshUrl,
+            scopes: $scopes,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Flow/ClientCredentials.php
+++ b/src/Spec/Flow/ClientCredentials.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Flow;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Configuration for the OAuth2 Client Credentials flow.
+ *
+ * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class ClientCredentials extends OA\Flow
+{
+    /**
+     * @param array<string,string>|null $scopes
+     * @param array<string,mixed>|null  $x
+     */
+    public function __construct(
+        ?string $tokenUrl = null,
+        ?string $refreshUrl = null,
+        ?array $scopes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            flow: 'clientCredentials',
+            tokenUrl: $tokenUrl,
+            refreshUrl: $refreshUrl,
+            scopes: $scopes,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Flow/Implicit.php
+++ b/src/Spec/Flow/Implicit.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Flow;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Configuration for the OAuth2 Implicit flow.
+ *
+ * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Implicit extends OA\Flow
+{
+    /**
+     * @param array<string,string>|null $scopes
+     * @param array<string,mixed>|null  $x
+     */
+    public function __construct(
+        ?string $authorizationUrl = null,
+        ?string $refreshUrl = null,
+        ?array $scopes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            flow: 'implicit',
+            authorizationUrl: $authorizationUrl,
+            refreshUrl: $refreshUrl,
+            scopes: $scopes,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Flow/Password.php
+++ b/src/Spec/Flow/Password.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Flow;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Configuration for the OAuth2 Resource Owner Password flow.
+ *
+ * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Password extends OA\Flow
+{
+    /**
+     * @param array<string,string>|null $scopes
+     * @param array<string,mixed>|null  $x
+     */
+    public function __construct(
+        ?string $tokenUrl = null,
+        ?string $refreshUrl = null,
+        ?array $scopes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            flow: 'password',
+            tokenUrl: $tokenUrl,
+            refreshUrl: $refreshUrl,
+            scopes: $scopes,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+use OpenApi\Undefined;
+
+/**
+ * Describes a single HTTP header.
+ *
+ * @see [Header Object](https://spec.openapis.org/oas/v3.1.1.html#header-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class Header extends AbstractAttribute
+{
+    /**
+     * @param string|null              $header      The header name (component key)
+     * @param string|null              $description A brief description of the header (CommonMark syntax)
+     * @param bool|null                $required    Whether the header is mandatory
+     * @param bool|null                $deprecated  Whether the header is deprecated
+     * @param string|null              $ref         A JSON Reference to a reusable header
+     * @param string|null              $style       How the header value is serialized
+     * @param bool|null                $explode     Whether arrays/objects generate separate parameters
+     * @param Schema|null              $schema      The schema defining the type for the header
+     * @param mixed                    $example     Example of the header's value
+     * @param list<Example>|null       $examples    Examples of the header's value
+     * @param list<MediaType>|null     $content     Content-type based header serialization
+     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $header = null,
+        public ?string $description = null,
+        public ?bool $required = null,
+        public ?bool $deprecated = null,
+        public ?string $ref = null,
+        public ?string $style = null,
+        public ?bool $explode = null,
+        public ?Schema $schema = null,
+        public mixed $example = Undefined::UNDEFINED,
+        public ?array $examples = null,
+        public ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [
+            Response::class => 'headers[]',
+            Encoding::class => 'headers[]',
+        ];
+    }
+
+    public function contains(): array
+    {
+        return [
+            MediaType::class => 'content[]',
+            Example::class => 'examples[]',
+        ];
+    }
+}

--- a/src/Spec/Info.php
+++ b/src/Spec/Info.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Metadata about the API.
+ *
+ * @see [Info Object](https://spec.openapis.org/oas/v3.1.1.html#info-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Info extends AbstractAttribute
+{
+    /**
+     * @param string|null              $title          The title of the API
+     * @param string|null              $description    A description of the API (CommonMark syntax)
+     * @param string|null              $termsOfService A URL to the Terms of Service for the API
+     * @param string|null              $version        The version of the API document
+     * @param Contact|null             $contact        Contact information for the API
+     * @param License|null             $license        License information for the API
+     * @param string|null              $summary        A short summary of the API
+     * @param array<string,mixed>|null $x              Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $title = null,
+        public ?string $description = null,
+        public ?string $termsOfService = null,
+        public ?string $version = null,
+        public ?Contact $contact = null,
+        public ?License $license = null,
+        public ?string $summary = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [
+            Contact::class => 'contact',
+            License::class => 'license',
+        ];
+    }
+}

--- a/src/Spec/License.php
+++ b/src/Spec/License.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * License information for the exposed API.
+ *
+ * @see [License Object](https://spec.openapis.org/oas/v3.1.1.html#license-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class License extends AbstractAttribute
+{
+    /**
+     * @param string|null              $name       The license name used for the API
+     * @param string|null              $identifier An SPDX license expression for the API
+     * @param string|null              $url        A URL to the license used for the API
+     * @param array<string,mixed>|null $x          Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $identifier = null,
+        public ?string $url = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Info::class => 'license'];
+    }
+}

--- a/src/Spec/Link.php
+++ b/src/Spec/Link.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes a possible design-time link for a response.
+ *
+ * @see [Link Object](https://spec.openapis.org/oas/v3.1.1.html#link-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Link extends AbstractAttribute
+{
+    /**
+     * @param string|null              $link         Reusable link identifier (component key)
+     * @param string|null              $operationRef A relative or absolute URI reference to a linked operation
+     * @param string|null              $operationId  The name of an existing operation (mutually exclusive with operationRef)
+     * @param array<string,mixed>|null $parameters   Values to pass to the linked operation's parameters
+     * @param mixed                    $requestBody  A value to use as the request body for the linked operation
+     * @param string|null              $description  A description of the link (CommonMark syntax)
+     * @param string|null              $ref          A JSON Reference to a reusable link
+     * @param Server|null              $server       A server object to be used by the target operation
+     * @param array<string,mixed>|null $x            Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $link = null,
+        public ?string $operationRef = null,
+        public ?string $operationId = null,
+        public ?array $parameters = null,
+        public mixed $requestBody = null,
+        public ?string $description = null,
+        public ?string $ref = null,
+        public ?Server $server = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->link !== null && $this->ref === null;
+    }
+
+    public function merge(): array
+    {
+        return [Response::class => 'links[]'];
+    }
+}

--- a/src/Spec/MediaType.php
+++ b/src/Spec/MediaType.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+use OpenApi\Undefined;
+
+/**
+ * Describes the content payload for a specific media type.
+ *
+ * @see [Media Type Object](https://spec.openapis.org/oas/v3.1.1.html#media-type-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class MediaType extends AbstractAttribute
+{
+    /**
+     * @param string|null                                $mediaType The media type identifier (e.g. 'application/json')
+     * @param Schema|null                                $schema    The schema defining the content
+     * @param mixed                                      $example   Example of the media type content
+     * @param list<Example>|null                         $examples  Examples of the media type content
+     * @param list<Encoding>|array<string,Encoding>|null $encoding  Encoding information for specific properties
+     * @param array<string,mixed>|null                   $x         Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $mediaType = null,
+        public ?Schema $schema = null,
+        public mixed $example = Undefined::UNDEFINED,
+        public ?array $examples = null,
+        public ?array $encoding = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [
+            Response::class => 'content[]',
+            RequestBody::class => 'content[]',
+            Parameter::class => 'content[]',
+        ];
+    }
+
+    public function contains(): array
+    {
+        return [
+            Encoding::class => 'encoding[]',
+            Example::class => 'examples[]',
+        ];
+    }
+}

--- a/src/Spec/OpenApi.php
+++ b/src/Spec/OpenApi.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * The root element of an OpenAPI definition.
+ *
+ * @see [OpenAPI Object](https://spec.openapis.org/oas/v3.1.1.html#openapi-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class OpenApi extends AbstractAttribute
+{
+    /**
+     * @param string|null                     $version  The OpenAPI specification version (e.g. '3.1.0')
+     * @param list<Security\Requirement>|null $security Default security requirements for the API
+     * @param array<string,mixed>|null        $x        Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $version = null,
+        /**
+         * @var list<Security\Requirement>|null
+         */
+        public ?array $security = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [Security\Requirement::class => 'security[]'];
+    }
+}

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes a single API operation on a path.
+ *
+ * Typed subclasses pre-fill the HTTP method — use them instead of specifying method manually:
+ *
+ *   #[OA\Operation\Get(path: '/pets/{id}', responses: [
+ *       new OA\Response(response: 200, description: 'A pet', content: [
+ *           new OA\MediaType(schema: new OA\Schema(ref: Pet::class)),
+ *       ]),
+ *   ])]
+ *   public function show(int $id) {}
+ *
+ * Produces:
+ *   paths:
+ *     /pets/{id}:
+ *       get:
+ *         operationId: show
+ *         responses:
+ *           '200':
+ *             description: A pet
+ *             content:
+ *               application/json:
+ *                 schema:
+ *                   $ref: '#/components/schemas/Pet'
+ *
+ * For webhooks, use `webhook` instead of `path`:
+ *
+ *   #[OA\Operation\Post(webhook: 'petAdopted', responses: [...])]
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ * @see [Webhooks](https://spec.openapis.org/oas/v3.1.1.html#fixed-fields)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Operation extends AbstractAttribute
+{
+    /**
+     * @param string|null                     $path         The URL path for the operation
+     * @param string|null                     $webhook      The webhook name (mutually exclusive with path)
+     * @param string|null                     $method       The HTTP method (get, post, put, delete, etc.)
+     * @param string|null                     $operationId  Unique identifier for the operation
+     * @param string|null                     $summary      A short summary of what the operation does
+     * @param string|null                     $description  A verbose explanation of the operation (CommonMark syntax)
+     * @param list<string>|null               $tags         Tags for API documentation grouping
+     * @param list<Parameter>|null            $parameters   Parameters applicable to this operation
+     * @param RequestBody|null                $requestBody  The request body applicable to this operation
+     * @param list<Response>|null             $responses    The list of possible responses
+     * @param array<string,mixed>|null        $callbacks    Possible out-of-band callbacks related to the operation
+     * @param bool|null                       $deprecated   Whether the operation is deprecated
+     * @param list<Security\Requirement>|null $security     Security mechanisms that can be used for this operation
+     * @param list<Server>|null               $servers      Alternative servers for this operation
+     * @param ExternalDocumentation|null      $externalDocs Additional external documentation
+     * @param array<string,mixed>|null        $x            Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $path = null,
+        public ?string $webhook = null,
+        public ?string $method = null,
+        public ?string $operationId = null,
+        public ?string $summary = null,
+        public ?string $description = null,
+        public ?array $tags = null,
+        public ?array $parameters = null,
+        public ?RequestBody $requestBody = null,
+        public ?array $responses = null,
+        public ?array $callbacks = null,
+        public ?bool $deprecated = null,
+        public ?array $security = null,
+        public ?array $servers = null,
+        public ?ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [
+            Parameter::class => 'parameters[]',
+            Response::class => 'responses[]',
+            RequestBody::class => 'requestBody',
+            Server::class => 'servers[]',
+            Security\Requirement::class => 'security[]',
+        ];
+    }
+}

--- a/src/Spec/Operation/Delete.php
+++ b/src/Spec/Operation/Delete.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP DELETE operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Delete extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'delete',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Get.php
+++ b/src/Spec/Operation/Get.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP GET operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Get extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'get',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Head.php
+++ b/src/Spec/Operation/Head.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP HEAD operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Head extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'head',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Options.php
+++ b/src/Spec/Operation/Options.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP OPTIONS operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Options extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'options',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Patch.php
+++ b/src/Spec/Operation/Patch.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP PATCH operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Patch extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'patch',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Post.php
+++ b/src/Spec/Operation/Post.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP POST operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Post extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'post',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Put.php
+++ b/src/Spec/Operation/Put.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP PUT operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Put extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'put',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Operation/Trace.php
+++ b/src/Spec/Operation/Trace.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Operation;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shorthand for an HTTP TRACE operation.
+ *
+ * @see [Operation Object](https://spec.openapis.org/oas/v3.1.1.html#operation-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Trace extends OA\Operation
+{
+    /**
+     * @param list<string>|null                  $tags
+     * @param list<OA\Parameter>|null            $parameters
+     * @param list<OA\Response>|null             $responses
+     * @param array<string,mixed>|null           $callbacks
+     * @param list<OA\Security\Requirement>|null $security
+     * @param list<OA\Server>|null               $servers
+     * @param array<string,mixed>|null           $x
+     */
+    public function __construct(
+        ?string $path = null,
+        ?string $webhook = null,
+        ?string $operationId = null,
+        ?string $summary = null,
+        ?string $description = null,
+        ?array $tags = null,
+        ?array $parameters = null,
+        ?OA\RequestBody $requestBody = null,
+        ?array $responses = null,
+        ?array $callbacks = null,
+        ?bool $deprecated = null,
+        ?array $security = null,
+        ?array $servers = null,
+        ?OA\ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            webhook: $webhook,
+            method: 'trace',
+            operationId: $operationId,
+            summary: $summary,
+            description: $description,
+            tags: $tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $deprecated,
+            security: $security,
+            servers: $servers,
+            externalDocs: $externalDocs,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+use OpenApi\Undefined;
+
+/**
+ * Describes a single operation parameter.
+ *
+ * Typed subtypes pre-fill `in` (and `required` for path):
+ * - `OA\Parameter\Path` - path parameters (in: path, required: true)
+ * - `OA\Parameter\Query` - query string parameters (in: query)
+ * - `OA\Parameter\Header` - header parameters (in: header)
+ * - `OA\Parameter\Cookie` - cookie parameters (in: cookie)
+ *
+ * Inline on an operation:
+ *
+ *   #[OA\Operation\Get(path: '/pets', parameters: [
+ *       new OA\Parameter\Query(name: 'status', schema: new OA\Schema(type: 'string', enum: ['active', 'sold'])),
+ *   ])]
+ *
+ * Or as a reusable component (set `parameter` for the component key):
+ *
+ *   #[OA\Parameter\Path(parameter: 'petId', name: 'id', schema: new OA\Schema(type: 'integer'))]
+ *
+ * Produces:
+ *   components:
+ *     parameters:
+ *       petId:
+ *         name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *
+ * @see [Parameter Object](https://spec.openapis.org/oas/v3.1.1.html#parameter-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Parameter extends AbstractAttribute
+{
+    /**
+     * @param string|null              $parameter       Reusable parameter identifier (component key)
+     * @param string|null              $name            The name of the parameter
+     * @param string|null              $in              The location of the parameter (query, header, path, cookie)
+     * @param string|null              $description     A brief description of the parameter (CommonMark syntax)
+     * @param bool|null                $required        Whether the parameter is mandatory
+     * @param bool|null                $deprecated      Whether the parameter is deprecated
+     * @param bool|null                $allowEmptyValue Whether empty-valued parameters are allowed
+     * @param string|null              $ref             A JSON Reference to a reusable parameter
+     * @param string|null              $style           How the parameter value is serialized
+     * @param bool|null                $explode         Whether arrays/objects generate separate parameters
+     * @param bool|null                $allowReserved   Whether reserved characters are allowed without encoding
+     * @param Schema|null              $schema          The schema defining the type for the parameter
+     * @param mixed                    $example         Example of the parameter's value
+     * @param list<Example>|null       $examples        Examples of the parameter's value
+     * @param list<MediaType>|null     $content         Content-type based parameter serialization
+     * @param array<string,mixed>|null $x               Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $parameter = null,
+        public ?string $name = null,
+        public ?string $in = null,
+        public ?string $description = null,
+        public ?bool $required = null,
+        public ?bool $deprecated = null,
+        public ?bool $allowEmptyValue = null,
+        public ?string $ref = null,
+        public ?string $style = null,
+        public ?bool $explode = null,
+        public ?bool $allowReserved = null,
+        public ?Schema $schema = null,
+        public mixed $example = Undefined::UNDEFINED,
+        public ?array $examples = null,
+        public ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->ref === null && $this->parameter !== null;
+    }
+
+    public function merge(): array
+    {
+        return [
+            Operation::class => 'parameters[]',
+            PathItem::class => 'parameters[]',
+        ];
+    }
+
+    public function contains(): array
+    {
+        return [
+            MediaType::class => 'content[]',
+            Example::class => 'examples[]',
+        ];
+    }
+}

--- a/src/Spec/Parameter/Cookie.php
+++ b/src/Spec/Parameter/Cookie.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Parameter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Undefined;
+
+/**
+ * A parameter passed via an HTTP cookie.
+ *
+ * @see [Parameter Object](https://spec.openapis.org/oas/v3.1.1.html#parameter-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Cookie extends OA\Parameter
+{
+    /**
+     * @param list<OA\Example>|null    $examples
+     * @param list<OA\MediaType>|null  $content
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $parameter = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?bool $required = null,
+        ?bool $deprecated = null,
+        ?string $ref = null,
+        ?bool $explode = null,
+        ?OA\Schema $schema = null,
+        mixed $example = Undefined::UNDEFINED,
+        ?array $examples = null,
+        ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            parameter: $parameter,
+            name: $name,
+            in: 'cookie',
+            description: $description,
+            required: $required,
+            deprecated: $deprecated,
+            ref: $ref,
+            explode: $explode,
+            schema: $schema,
+            example: $example,
+            examples: $examples,
+            content: $content,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Parameter/Header.php
+++ b/src/Spec/Parameter/Header.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Parameter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Undefined;
+
+/**
+ * A parameter passed via an HTTP header.
+ *
+ * @see [Parameter Object](https://spec.openapis.org/oas/v3.1.1.html#parameter-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Header extends OA\Parameter
+{
+    /**
+     * @param list<OA\Example>|null    $examples
+     * @param list<OA\MediaType>|null  $content
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $parameter = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?bool $required = null,
+        ?bool $deprecated = null,
+        ?string $ref = null,
+        ?bool $explode = null,
+        ?OA\Schema $schema = null,
+        mixed $example = Undefined::UNDEFINED,
+        ?array $examples = null,
+        ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            parameter: $parameter,
+            name: $name,
+            in: 'header',
+            description: $description,
+            required: $required,
+            deprecated: $deprecated,
+            ref: $ref,
+            explode: $explode,
+            schema: $schema,
+            example: $example,
+            examples: $examples,
+            content: $content,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Parameter/Path.php
+++ b/src/Spec/Parameter/Path.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Parameter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Undefined;
+
+/**
+ * A parameter passed via the URL path (always required).
+ *
+ * @see [Parameter Object](https://spec.openapis.org/oas/v3.1.1.html#parameter-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Path extends OA\Parameter
+{
+    /**
+     * @param list<OA\Example>|null    $examples
+     * @param list<OA\MediaType>|null  $content
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $parameter = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?bool $deprecated = null,
+        ?string $ref = null,
+        ?string $style = null,
+        ?bool $explode = null,
+        ?OA\Schema $schema = null,
+        mixed $example = Undefined::UNDEFINED,
+        ?array $examples = null,
+        ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            parameter: $parameter,
+            name: $name,
+            in: 'path',
+            description: $description,
+            required: true,
+            deprecated: $deprecated,
+            ref: $ref,
+            style: $style,
+            explode: $explode,
+            schema: $schema,
+            example: $example,
+            examples: $examples,
+            content: $content,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Parameter/Query.php
+++ b/src/Spec/Parameter/Query.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Parameter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Undefined;
+
+/**
+ * A parameter passed via the URL query string.
+ *
+ * @see [Parameter Object](https://spec.openapis.org/oas/v3.1.1.html#parameter-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Query extends OA\Parameter
+{
+    /**
+     * @param list<OA\Example>|null    $examples
+     * @param list<OA\MediaType>|null  $content
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $parameter = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?bool $required = null,
+        ?bool $deprecated = null,
+        ?bool $allowEmptyValue = null,
+        ?string $ref = null,
+        ?string $style = null,
+        ?bool $explode = null,
+        ?bool $allowReserved = null,
+        ?OA\Schema $schema = null,
+        mixed $example = Undefined::UNDEFINED,
+        ?array $examples = null,
+        ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            parameter: $parameter,
+            name: $name,
+            in: 'query',
+            description: $description,
+            required: $required,
+            deprecated: $deprecated,
+            allowEmptyValue: $allowEmptyValue,
+            ref: $ref,
+            style: $style,
+            explode: $explode,
+            allowReserved: $allowReserved,
+            schema: $schema,
+            example: $example,
+            examples: $examples,
+            content: $content,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/PathItem.php
+++ b/src/Spec/PathItem.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes shared metadata for all operations under a path.
+ *
+ * Place on a controller class — the path is inferred from its operations.
+ * Parameters, summary, description and servers are emitted at path level in the
+ * OpenAPI output. Prefix, tags, security and responses are controller-level features
+ * that compose via class hierarchy and apply to all contained operations.
+ *
+ * Shared path-level properties (parameters, summary, description, servers per OpenAPI spec):
+ *
+ *   #[PathItem(parameters: [new Parameter\Path(name: 'id', schema: new Schema(type: 'integer'))])]
+ *   class ProductController {
+ *       #[Operation\Get(path: '/products/{id}')]
+ *       public function get() {}
+ *   }
+ *
+ * The path in the output is inferred from the operations — no need to declare it
+ * on PathItem, avoiding duplication.
+ *
+ * Prefix composition with inherited metadata:
+ *
+ *   #[PathItem(prefix: '/api/v1')]
+ *   class BaseController {}
+ *
+ *   #[PathItem(prefix: '/users', tags: ['Users'], security: [new Security\Requirement(scheme: 'bearerAuth')])]
+ *   #[Response(response: 401, description: 'Unauthorized')]
+ *   #[Response(response: 500, description: 'Server error')]
+ *   class UserController extends BaseController {
+ *       #[Operation\Get(path: '/list')]       // resolved: /api/v1/users/list, tags: ['Users']
+ *       public function list() {}
+ *
+ *       #[Operation\Get(path: '/{id}')]       // resolved: /api/v1/users/{id}, tags: ['Users']
+ *       public function get() {}
+ *   }
+ *
+ * Prefixes compose by walking the class hierarchy — each ancestor PathItem contributes
+ * its prefix segment. All collection properties merge additively: tags, security,
+ * responses, and parameters accumulate from the full ancestor chain. Deduplication
+ * is by value (tags), by scheme (security), by status code (responses), and by
+ * name+in (parameters).
+ *
+ * @see [Path Item Object](https://spec.openapis.org/oas/v3.1.1.html#path-item-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class PathItem extends AbstractAttribute
+{
+    /**
+     * @param string|null                     $ref         A JSON Reference to a reusable path item
+     * @param string|null                     $prefix      Path prefix — composable via class hierarchy
+     * @param string|null                     $summary     An optional summary, intended to apply to all operations in this path
+     * @param string|null                     $description An optional description, intended to apply to all operations in this path
+     * @param list<Parameter>|null            $parameters  Parameters applicable to all operations under this path
+     * @param list<Server>|null               $servers     Alternative servers for all operations under this path
+     * @param list<string>|null               $tags        Tags to clone to contained operations
+     * @param list<Security\Requirement>|null $security    Security requirements to clone to contained operations
+     * @param list<Response>|null             $responses   Shared responses to clone to contained operations
+     * @param array<string,mixed>|null        $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $ref = null,
+        public ?string $prefix = null,
+        public ?string $summary = null,
+        public ?string $description = null,
+        public ?array $parameters = null,
+        public ?array $servers = null,
+        public ?array $tags = null,
+        public ?array $security = null,
+        public ?array $responses = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    /** Resolved path — set by augmenter or HybridBridge, not user-authored. */
+    public ?string $path = null;
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [
+            Parameter::class => 'parameters[]',
+            Server::class => 'servers[]',
+            Response::class => 'responses[]',
+            Security\Requirement::class => 'security[]',
+        ];
+    }
+}

--- a/src/Spec/Property.php
+++ b/src/Spec/Property.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Defines a single property within a Schema object.
+ *
+ * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::IS_REPEATABLE)]
+class Property extends AbstractAttribute
+{
+    /**
+     * @param string|null              $property The property name
+     * @param Schema|null              $schema   The schema defining the property type and constraints
+     * @param array<string,mixed>|null $x        Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $property = null,
+        public ?Schema $schema = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [];
+    }
+}

--- a/src/Spec/RequestBody.php
+++ b/src/Spec/RequestBody.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes a single request body.
+ *
+ * @see [Request Body Object](https://spec.openapis.org/oas/v3.1.1.html#request-body-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class RequestBody extends AbstractAttribute
+{
+    /**
+     * @param string|null              $request     Reusable request body identifier (component key)
+     * @param string|null              $description A brief description of the request body (CommonMark syntax)
+     * @param bool|null                $required    Whether the request body is required
+     * @param string|null              $ref         A JSON Reference to a reusable request body
+     * @param list<MediaType>|null     $content     The content of the request body
+     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $request = null,
+        public ?string $description = null,
+        public ?bool $required = null,
+        public ?string $ref = null,
+        public ?array $content = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->request !== null;
+    }
+
+    public function merge(): array
+    {
+        return [Operation::class => 'requestBody'];
+    }
+
+    public function contains(): array
+    {
+        return [MediaType::class => 'content[]'];
+    }
+}

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Describes a single response from an API operation.
+ *
+ * @see [Response Object](https://spec.openapis.org/oas/v3.1.1.html#response-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Response extends AbstractAttribute
+{
+    /**
+     * @param string|int|null          $response    The HTTP status code or 'default'
+     * @param string|null              $description A description of the response (CommonMark syntax)
+     * @param string|null              $ref         A JSON Reference to a reusable response
+     * @param list<Header>|null        $headers     Headers sent with the response
+     * @param list<MediaType>|null     $content     Possible response payloads
+     * @param list<Link>|null          $links       Design-time links for the response
+     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public string|int|null $response = null,
+        public ?string $description = null,
+        public ?string $ref = null,
+        public ?array $headers = null,
+        public ?array $content = null,
+        public ?array $links = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return $this->ref === null && $this->response !== null;
+    }
+
+    public function merge(): array
+    {
+        return [Operation::class => 'responses[]', PathItem::class => 'responses[]'];
+    }
+
+    public function contains(): array
+    {
+        return [
+            Header::class => 'headers[]',
+            MediaType::class => 'content[]',
+            Link::class => 'links[]',
+        ];
+    }
+}

--- a/src/Spec/Schema.php
+++ b/src/Spec/Schema.php
@@ -1,0 +1,207 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+use OpenApi\Undefined;
+
+/**
+ * Defines the structure and validation rules for a data type.
+ *
+ * On a class — becomes a reusable component schema (name inferred from class):
+ *
+ *   #[OA\Schema]
+ *   class Pet {
+ *       #[OA\Property]
+ *       public string $name;
+ *       #[OA\Property]
+ *       public ?int $age;
+ *   }
+ *
+ * Produces:
+ *   components:
+ *     schemas:
+ *       Pet:
+ *         type: object
+ *         properties:
+ *           name: { type: string }
+ *           age: { type: integer, nullable: true }
+ *
+ * Inline — used within parameters, responses, or other schemas:
+ *
+ *   new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))
+ *
+ * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
+ * @see [JSON Schema](https://json-schema.org/draft/2020-12/json-schema-validation)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Schema extends AbstractAttribute
+{
+    /**
+     * @param string|null                                                             $schema                Reusable schema identifier (component key)
+     * @param string|null                                                             $title                 A title for the schema
+     * @param string|null                                                             $description           A description of the schema (CommonMark syntax)
+     * @param string|null                                                             $ref                   A JSON Reference to a reusable schema
+     * @param string|list<string>|null                                                $type                  The value type(s) (string, number, integer, boolean, array, object, null)
+     * @param string|null                                                             $format                Further refines the type (e.g. int32, int64, float, double, date-time, email)
+     * @param bool|null                                                               $nullable              Whether the value can be null (OAS 3.0 only; use type array in 3.1+)
+     * @param int|null                                                                $minLength             Minimum string length
+     * @param int|null                                                                $maxLength             Maximum string length
+     * @param string|null                                                             $pattern               Regular expression pattern the string must match
+     * @param string|null                                                             $contentMediaType      The media type of string content encoding
+     * @param string|null                                                             $contentEncoding       The encoding used for string content (e.g. base64)
+     * @param int|float|null                                                          $minimum               Minimum numeric value (inclusive)
+     * @param int|float|null                                                          $maximum               Maximum numeric value (inclusive)
+     * @param int|float|bool|null                                                     $exclusiveMinimum      Exclusive minimum value
+     * @param int|float|bool|null                                                     $exclusiveMaximum      Exclusive maximum value
+     * @param int|float|null                                                          $multipleOf            The value must be a multiple of this number
+     * @param Schema|string|null                                                      $items                 Schema for array items
+     * @param int|null                                                                $minItems              Minimum number of array items
+     * @param int|null                                                                $maxItems              Maximum number of array items
+     * @param bool|null                                                               $uniqueItems           Whether array items must be unique
+     * @param list<Schema>|null                                                       $prefixItems           Schemas for positional array items (tuple validation)
+     * @param Schema|bool|null                                                        $contains              Schema that at least one array item must match
+     * @param int|null                                                                $minContains           Minimum number of items matching contains
+     * @param int|null                                                                $maxContains           Maximum number of items matching contains
+     * @param Schema|bool|null                                                        $unevaluatedItems      Schema for items not covered by other keywords
+     * @param list<Property|Schema>|null                                              $properties            Object property definitions
+     * @param list<string>|null                                                       $required              List of required property names
+     * @param Schema|bool|null                                                        $additionalProperties  Schema or boolean for additional properties
+     * @param array<string,Schema>|null                                               $patternProperties     Schemas for properties matching regex patterns
+     * @param int|null                                                                $minProperties         Minimum number of properties
+     * @param int|null                                                                $maxProperties         Maximum number of properties
+     * @param Schema|bool|null                                                        $unevaluatedProperties Schema for properties not covered by other keywords
+     * @param Schema|null                                                             $propertyNames         Schema that property names must validate against
+     * @param array<string,list<string>>|null                                         $dependentRequired     Property-level required dependencies
+     * @param array<string,Schema>|null                                               $dependentSchemas      Property-level schema dependencies
+     * @param list<Schema>|null                                                       $allOf                 All schemas must match (AND composition)
+     * @param list<Schema>|null                                                       $anyOf                 At least one schema must match (OR composition)
+     * @param list<Schema>|null                                                       $oneOf                 Exactly one schema must match (XOR composition)
+     * @param Schema|null                                                             $not                   The schema must NOT match
+     * @param Schema|null                                                             $if                    Conditional schema (if-then-else)
+     * @param Schema|null                                                             $then                  Applied when 'if' succeeds
+     * @param Schema|null                                                             $else                  Applied when 'if' fails
+     * @param list<string|int|float|bool|\UnitEnum|class-string<\UnitEnum>|null>|null $enum                  Allowed values
+     * @param mixed                                                                   $const                 A single allowed value
+     * @param mixed                                                                   $example               An example value
+     * @param list<mixed>|null                                                        $examples              A list of example values
+     * @param bool|null                                                               $deprecated            Whether the schema is deprecated
+     * @param bool|null                                                               $readOnly              Whether the value is read-only
+     * @param bool|null                                                               $writeOnly             Whether the value is write-only
+     * @param mixed                                                                   $default               The default value
+     * @param Discriminator|null                                                      $discriminator         Discriminator for polymorphism
+     * @param ExternalDocumentation|null                                              $externalDocs          Additional external documentation
+     * @param Xml|null                                                                $xml                   XML representation metadata
+     * @param array<string,mixed>|null                                                $x                     Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        // Identity
+        public ?string $schema = null,
+        public ?string $title = null,
+        public ?string $description = null,
+
+        // Reference
+        public ?string $ref = null,
+
+        // Core type
+        public string|array|null $type = null,
+        public ?string $format = null,
+        public ?bool $nullable = null,
+
+        // String constraints
+        public ?int $minLength = null,
+        public ?int $maxLength = null,
+        public ?string $pattern = null,
+        public ?string $contentMediaType = null,
+        public ?string $contentEncoding = null,
+
+        // Numeric constraints
+        public int|float|null $minimum = null,
+        public int|float|null $maximum = null,
+        public int|float|bool|null $exclusiveMinimum = null,
+        public int|float|bool|null $exclusiveMaximum = null,
+        public int|float|null $multipleOf = null,
+
+        // Array constraints
+        public Schema|string|null $items = null,
+        public ?int $minItems = null,
+        public ?int $maxItems = null,
+        public ?bool $uniqueItems = null,
+        public ?array $prefixItems = null,
+        public Schema|bool|null $contains = null,
+        public ?int $minContains = null,
+        public ?int $maxContains = null,
+        public Schema|bool|null $unevaluatedItems = null,
+
+        // Object constraints
+        public ?array $properties = null,
+        public ?array $required = null,
+        public Schema|bool|null $additionalProperties = null,
+        public ?array $patternProperties = null,
+        public ?int $minProperties = null,
+        public ?int $maxProperties = null,
+        public Schema|bool|null $unevaluatedProperties = null,
+        public ?Schema $propertyNames = null,
+        public ?array $dependentRequired = null,
+        public ?array $dependentSchemas = null,
+
+        // Composition
+        public ?array $allOf = null,
+        public ?array $anyOf = null,
+        public ?array $oneOf = null,
+        public ?Schema $not = null,
+
+        // Conditional
+        public ?Schema $if = null,
+        public ?Schema $then = null,
+        public ?Schema $else = null,
+
+        // Enum/const
+        public ?array $enum = null,
+        public mixed $const = Undefined::UNDEFINED,
+
+        // Examples
+        public mixed $example = Undefined::UNDEFINED,
+        public ?array $examples = null,
+
+        // Meta
+        public ?bool $deprecated = null,
+        public ?bool $readOnly = null,
+        public ?bool $writeOnly = null,
+        public mixed $default = Undefined::UNDEFINED,
+
+        // OpenAPI extensions on Schema
+        public ?Discriminator $discriminator = null,
+        public ?ExternalDocumentation $externalDocs = null,
+        public ?Xml $xml = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function merge(): array
+    {
+        return [
+            Property::class => 'schema',
+            Parameter::class => 'schema',
+            Header::class => 'schema',
+            MediaType::class => 'schema',
+        ];
+    }
+
+    public function contains(): array
+    {
+        return [
+            Property::class => 'properties[]',
+            self::class => 'properties[]',
+        ];
+    }
+}

--- a/src/Spec/Security/Requirement.php
+++ b/src/Spec/Security/Requirement.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A security requirement declaring which security schemes apply.
+ *
+ * Each requirement instance represents one entry in the security array (OR logic).
+ * Multiple schemes within a single requirement represent AND logic.
+ *
+ * @see [Security Requirement Object](https://spec.openapis.org/oas/v3.1.1.html#security-requirement-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Requirement extends OA\AbstractAttribute
+{
+    /**
+     * @param string|null                     $scheme  Single scheme name (shorthand for simple requirements)
+     * @param list<string>|null               $scopes  Scopes for the single scheme (OAuth2/OpenIdConnect)
+     * @param array<string,list<string>>|null $schemes Map of scheme names to scopes (for AND logic with multiple schemes)
+     * @param array<string,mixed>|null        $x       Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $scheme = null,
+        public ?array $scopes = null,
+        public ?array $schemes = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [OA\OpenApi::class => 'security[]', OA\Operation::class => 'security[]', OA\PathItem::class => 'security[]'];
+    }
+
+    /**
+     * Resolve to the normalized map format: ['schemeName' => [...scopes]].
+     *
+     * @return array<string, list<string>>
+     */
+    public function toArray(): array
+    {
+        if ($this->schemes !== null) {
+            return $this->schemes;
+        }
+
+        if ($this->scheme !== null) {
+            return [$this->scheme => $this->scopes ?? []];
+        }
+
+        return [];
+    }
+}

--- a/src/Spec/Security/Scheme.php
+++ b/src/Spec/Security/Scheme.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Defines a security scheme that can be used by the operations.
+ *
+ * Typed subtypes are available for each security scheme type:
+ * - `OA\Security\Scheme\Http` - HTTP authentication (Basic, Bearer, etc.)
+ * - `OA\Security\Scheme\ApiKey` - API key in header, query, or cookie
+ * - `OA\Security\Scheme\OAuth2` - OAuth2 with one or more flows
+ * - `OA\Security\Scheme\OpenIdConnect` - OpenID Connect discovery
+ * - `OA\Security\Scheme\MutualTls` - Mutual TLS authentication
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+class Scheme extends OA\AbstractAttribute
+{
+    /**
+     * @param string|null              $securityScheme   Reusable security scheme identifier (component key)
+     * @param string|null              $type             The type of the security scheme (apiKey, http, mutualTLS, oauth2, openIdConnect)
+     * @param string|null              $description      A description of the security scheme (CommonMark syntax)
+     * @param string|null              $name             The name of the header, query, or cookie parameter (apiKey)
+     * @param string|null              $in               The location of the API key (query, header, cookie)
+     * @param string|null              $scheme           The HTTP authorization scheme (http)
+     * @param string|null              $bearerFormat     A hint about the format of the bearer token (http/bearer)
+     * @param string|null              $openIdConnectUrl The OpenID Connect URL to discover configuration (openIdConnect)
+     * @param list<OA\Flow>|null       $flows            The available OAuth2 flows (oauth2)
+     * @param string|null              $ref              A JSON Reference to a reusable security scheme
+     * @param array<string,mixed>|null $x                Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $securityScheme = null,
+        public ?string $type = null,
+        public ?string $description = null,
+        public ?string $name = null,
+        public ?string $in = null,
+        public ?string $scheme = null,
+        public ?string $bearerFormat = null,
+        public ?string $openIdConnectUrl = null,
+        public ?array $flows = null,
+        public ?string $ref = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [OA\Flow::class => 'flows[]'];
+    }
+}

--- a/src/Spec/Security/Scheme/ApiKey.php
+++ b/src/Spec/Security/Scheme/ApiKey.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security\Scheme;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An API key security scheme (header, query, or cookie).
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class ApiKey extends OA\Security\Scheme
+{
+    /**
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $securityScheme = null,
+        ?string $description = null,
+        ?string $name = null,
+        ?string $in = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            securityScheme: $securityScheme,
+            type: 'apiKey',
+            description: $description,
+            name: $name,
+            in: $in,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Security/Scheme/Http.php
+++ b/src/Spec/Security/Scheme/Http.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security\Scheme;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An HTTP authentication security scheme (Basic, Bearer, etc.).
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Http extends OA\Security\Scheme
+{
+    /**
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $securityScheme = null,
+        ?string $description = null,
+        ?string $scheme = null,
+        ?string $bearerFormat = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            securityScheme: $securityScheme,
+            type: 'http',
+            description: $description,
+            scheme: $scheme,
+            bearerFormat: $bearerFormat,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Security/Scheme/MutualTls.php
+++ b/src/Spec/Security/Scheme/MutualTls.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security\Scheme;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A Mutual TLS security scheme.
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class MutualTls extends OA\Security\Scheme
+{
+    /**
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $securityScheme = null,
+        ?string $description = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            securityScheme: $securityScheme,
+            type: 'mutualTLS',
+            description: $description,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Security/Scheme/OAuth2.php
+++ b/src/Spec/Security/Scheme/OAuth2.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security\Scheme;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An OAuth2 security scheme with one or more flows.
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class OAuth2 extends OA\Security\Scheme
+{
+    /**
+     * @param list<OA\Flow>|null       $flows
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $securityScheme = null,
+        ?string $description = null,
+        ?array $flows = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            securityScheme: $securityScheme,
+            type: 'oauth2',
+            description: $description,
+            flows: $flows,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Security/Scheme/OpenIdConnect.php
+++ b/src/Spec/Security/Scheme/OpenIdConnect.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Security\Scheme;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An OpenID Connect Discovery security scheme.
+ *
+ * @see [Security Scheme Object](https://spec.openapis.org/oas/v3.1.1.html#security-scheme-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class OpenIdConnect extends OA\Security\Scheme
+{
+    /**
+     * @param array<string,mixed>|null $x
+     */
+    public function __construct(
+        ?string $securityScheme = null,
+        ?string $description = null,
+        ?string $openIdConnectUrl = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(
+            securityScheme: $securityScheme,
+            type: 'openIdConnect',
+            description: $description,
+            openIdConnectUrl: $openIdConnectUrl,
+            x: $x,
+        );
+    }
+}

--- a/src/Spec/Server.php
+++ b/src/Spec/Server.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Represents a Server.
+ *
+ * @see [Server Object](https://spec.openapis.org/oas/v3.1.1.html#server-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Server extends AbstractAttribute
+{
+    /**
+     * @param string|null               $url         A URL to the target host
+     * @param string|null               $description A description of the host (CommonMark syntax)
+     * @param list<ServerVariable>|null $variables   Variables for server URL template substitution
+     * @param array<string,mixed>|null  $x           Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $url = null,
+        public ?string $description = null,
+        public ?array $variables = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function merge(): array
+    {
+        return [PathItem::class => 'servers[]', Operation::class => 'servers[]'];
+    }
+
+    public function contains(): array
+    {
+        return [ServerVariable::class => 'variables[]'];
+    }
+}

--- a/src/Spec/ServerVariable.php
+++ b/src/Spec/ServerVariable.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Represents a Server Variable for server URL template substitution.
+ *
+ * @see [Server Variable Object](https://spec.openapis.org/oas/v3.1.1.html#server-variable-object)
+ */
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+class ServerVariable extends AbstractAttribute
+{
+    /**
+     * @param string|null              $serverVariable The variable name
+     * @param string|null              $default        The default value to use for substitution
+     * @param string|null              $description    A description of the server variable (CommonMark syntax)
+     * @param list<string>|null        $enum           Enumeration of allowed string values for substitution
+     * @param array<string,mixed>|null $x              Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $serverVariable = null,
+        public ?string $default = null,
+        public ?string $description = null,
+        public ?array $enum = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Server::class => 'variables[]'];
+    }
+}

--- a/src/Spec/Tag.php
+++ b/src/Spec/Tag.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Adds metadata to a single tag used by the Operation Object.
+ *
+ * @see [Tag Object](https://spec.openapis.org/oas/v3.1.1.html#tag-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Tag extends AbstractAttribute
+{
+    /**
+     * @param string|null                $name         The name of the tag
+     * @param string|null                $description  A description of the tag (CommonMark syntax)
+     * @param ExternalDocumentation|null $externalDocs Additional external documentation for this tag
+     * @param array<string,mixed>|null   $x            Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $description = null,
+        public ?ExternalDocumentation $externalDocs = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function isRoot(): bool
+    {
+        return true;
+    }
+
+    public function contains(): array
+    {
+        return [ExternalDocumentation::class => 'externalDocs'];
+    }
+}

--- a/src/Spec/Xml.php
+++ b/src/Spec/Xml.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+/**
+ * Metadata for XML representation of a schema property.
+ *
+ * @see [XML Object](https://spec.openapis.org/oas/v3.1.1.html#xml-object)
+ */
+#[\Attribute]
+class Xml extends AbstractAttribute
+{
+    /**
+     * @param string|null              $name      Replaces the name of the element/attribute
+     * @param string|null              $namespace The URI of the XML namespace
+     * @param string|null              $prefix    The namespace prefix to use
+     * @param bool|null                $attribute Whether the property translates to an XML attribute
+     * @param bool|null                $wrapped   Whether array items are wrapped in an additional element
+     * @param array<string,mixed>|null $x         Vendor extensions (x-* properties)
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $namespace = null,
+        public ?string $prefix = null,
+        public ?bool $attribute = null,
+        public ?bool $wrapped = null,
+        ?array $x = null,
+    ) {
+        parent::__construct(x: $x);
+    }
+
+    public function merge(): array
+    {
+        return [Schema::class => 'xml'];
+    }
+}

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Spec as OA;
+use OpenApi\Utils\SpecificationWalker;
+
+/**
+ * Flat container for all collected spec attributes.
+ */
+class Specification
+{
+    public OA\OpenApi $openapi;
+
+    public ?OA\Info $info = null;
+
+    /** @var list<OA\Server> */
+    public array $servers = [];
+
+    /** @var list<OA\Tag> */
+    public array $tags = [];
+
+    /** @var list<OA\ExternalDocumentation> */
+    public array $externalDocs = [];
+
+    /** @var list<OA\PathItem> */
+    public array $pathItems = [];
+
+    /** @var list<OA\Operation> */
+    public array $operations = [];
+
+    /** @var list<OA\Schema> */
+    public array $schemas = [];
+
+    /** @var list<OA\Response> */
+    public array $responses = [];
+
+    /** @var list<OA\Parameter> */
+    public array $parameters = [];
+
+    /** @var list<OA\RequestBody> */
+    public array $requestBodies = [];
+
+    /** @var list<OA\Header> */
+    public array $headers = [];
+
+    /** @var list<OA\Security\Scheme> */
+    public array $securitySchemes = [];
+
+    /** @var list<OA\Link> */
+    public array $links = [];
+
+    /** @var list<OA\Example> */
+    public array $examples = [];
+
+    public function __construct()
+    {
+        $this->openapi = new OA\OpenApi();
+    }
+
+    public function add(AttributeInterface ...$attributes): static
+    {
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof OA\Components) {
+                $this->addComponentsChildren($attribute);
+
+                continue;
+            }
+
+            match (true) {
+                $attribute instanceof OA\OpenApi => $this->openapi = $attribute,
+                $attribute instanceof OA\Info => $this->info = $attribute,
+                $attribute instanceof OA\Server => $this->servers[] = $attribute,
+                $attribute instanceof OA\Tag => $this->tags[] = $attribute,
+                $attribute instanceof OA\ExternalDocumentation => $this->externalDocs[] = $attribute,
+                $attribute instanceof OA\PathItem => $this->pathItems[] = $attribute,
+                $attribute instanceof OA\Operation => $this->operations[] = $attribute,
+                $attribute instanceof OA\Schema => $this->schemas[] = $attribute,
+                $attribute instanceof OA\Response => $this->responses[] = $attribute,
+                $attribute instanceof OA\Parameter => $this->parameters[] = $attribute,
+                $attribute instanceof OA\RequestBody => $this->requestBodies[] = $attribute,
+                $attribute instanceof OA\Header => $this->headers[] = $attribute,
+                $attribute instanceof OA\Security\Scheme => $this->securitySchemes[] = $attribute,
+                $attribute instanceof OA\Link => $this->links[] = $attribute,
+                $attribute instanceof OA\Example => $this->examples[] = $attribute,
+                default => throw OpenApiException::fromSource(
+                    'Unsupported root-level attribute: ' . $attribute::class,
+                    $attribute->getSourceLocation(),
+                ),
+            };
+        }
+
+        return $this;
+    }
+
+    private function addComponentsChildren(OA\Components $components): void
+    {
+        array_push($this->schemas, ...$components->schemas);
+        array_push($this->parameters, ...$components->parameters);
+        array_push($this->responses, ...$components->responses);
+        array_push($this->requestBodies, ...$components->requestBodies);
+        array_push($this->headers, ...$components->headers);
+        array_push($this->securitySchemes, ...$components->securitySchemes);
+        array_push($this->links, ...$components->links);
+        array_push($this->examples, ...$components->examples);
+        array_push($this->pathItems, ...$components->pathItems);
+    }
+
+    public function getWalker(): SpecificationWalker
+    {
+        return new SpecificationWalker($this);
+    }
+}

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -1,0 +1,291 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+use OpenApi\AttributeInterface;
+use OpenApi\OpenApiException;
+use OpenApi\Spec as OA;
+
+/**
+ * Creates spec attribute instances from PHP reflectors.
+ *
+ * Encapsulates: reading PHP attributes, stack-resolving siblings (merge),
+ * and hierarchical absorb (contains). Shared between the Assembler (initial
+ * collection) and augmenter pipes that need to manufacture spec objects
+ * from reflection (e.g. ExpandHierarchy for non-schema ancestor members).
+ */
+class AttributeFactory
+{
+    /**
+     * Read and resolve attributes from a single member reflector.
+     *
+     * For methods, also resolves parameter-level attributes into the method-level ones.
+     *
+     * @return list<AttributeInterface>
+     */
+    public function fromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        if ($reflector instanceof \ReflectionMethod) {
+            $outer = $this->resolveNesting($this->readAttributes($reflector));
+            $inner = [];
+            foreach ($reflector->getParameters() as $parameter) {
+                array_push($inner, ...$this->resolveNesting($this->readAttributes($parameter)));
+            }
+
+            return $this->resolveHierarchy($outer, $inner);
+        }
+
+        return $this->resolveNesting($this->readAttributes($reflector));
+    }
+
+    /**
+     * Read and resolve attributes from a class's own members (properties, constructor params, constants).
+     *
+     * Does NOT include the class-level attributes themselves or methods.
+     * Returns inner attributes suitable for hierarchical absorption into a class-level container.
+     *
+     * @return list<AttributeInterface>
+     */
+    public function membersOf(\ReflectionClass $class): array
+    {
+        $inner = [];
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->isPromoted() || $property->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            array_push($inner, ...$this->resolveNesting($this->readAttributes($property)));
+        }
+
+        $constructor = $class->getConstructor();
+        if ($constructor) {
+            foreach ($constructor->getParameters() as $parameter) {
+                array_push($inner, ...$this->resolveNesting($this->readAttributes($parameter)));
+            }
+        }
+
+        foreach ($class->getReflectionConstants() as $constant) {
+            if ($constant->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            array_push($inner, ...$this->resolveNesting($this->readAttributes($constant)));
+        }
+
+        foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            $resolved = $this->resolveNesting($this->readAttributes($method));
+            foreach ($resolved as $attribute) {
+                if ($attribute instanceof OA\Property) {
+                    $inner[] = $attribute;
+                }
+            }
+        }
+
+        return $inner;
+    }
+
+    /**
+     * Check whether a reflector has any OpenAPI attributes.
+     */
+    public function hasAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): bool
+    {
+        return $reflector->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF) !== [];
+    }
+
+    /**
+     * Check whether a method only produces Property attributes (no operations).
+     */
+    public function hasOnlyProperties(\ReflectionMethod $method): bool
+    {
+        $reflectionAttributes = $method->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF);
+        if ($reflectionAttributes === []) {
+            return false;
+        }
+
+        foreach ($reflectionAttributes as $reflectionAttribute) {
+            $name = $reflectionAttribute->getName();
+            if (!is_a($name, OA\Property::class, true) && !is_a($name, OA\Schema::class, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Stack-resolve: merge sibling attributes on the same reflector using merge().
+     *
+     * @param  list<AttributeInterface> $attributes
+     * @return list<AttributeInterface>
+     */
+    protected function resolveNesting(array $attributes): array
+    {
+        if (count($attributes) <= 1) {
+            return $attributes;
+        }
+
+        $merged = [];
+
+        foreach ($attributes as $index => $attribute) {
+            $mergeTargets = $attribute->merge();
+
+            if ($mergeTargets === []) {
+                continue;
+            }
+
+            $matchingTarget = null;
+            $matchingSlot = null;
+            foreach ($attributes as $candidateIndex => $candidate) {
+                if ($candidateIndex === $index || isset($merged[$candidateIndex])) {
+                    continue;
+                }
+
+                foreach ($mergeTargets as $targetClass => $slot) {
+                    if ($candidate instanceof $targetClass) {
+                        if ($matchingTarget instanceof AttributeInterface) {
+                            throw OpenApiException::fromSource(
+                                sprintf('Ambiguous merge: %s matches multiple siblings on the same target', $attribute::class),
+                                $attribute->getSourceLocation(),
+                            );
+                        }
+                        $matchingTarget = $candidate;
+                        $matchingSlot = $slot;
+                    }
+                }
+            }
+
+            if ($matchingTarget instanceof AttributeInterface) {
+                $this->nestChild($matchingTarget, $attribute, $matchingSlot);
+                $merged[$index] = true;
+            }
+        }
+
+        $roots = [];
+        foreach ($attributes as $index => $attribute) {
+            if (!isset($merged[$index])) {
+                $roots[] = $attribute;
+            }
+        }
+
+        return $roots;
+    }
+
+    /**
+     * Hierarchical absorb: outer-level attributes absorb inner-level attributes using contains().
+     *
+     * @param  list<AttributeInterface> $outer
+     * @param  list<AttributeInterface> $inner
+     * @return list<AttributeInterface>
+     */
+    public function resolveHierarchy(array $outer, array $inner): array
+    {
+        foreach ($inner as $innerAttribute) {
+            $matchingContainer = null;
+            $matchingSlot = null;
+
+            foreach ($outer as $outerAttribute) {
+                $containsTypes = $outerAttribute->contains();
+                if ($containsTypes === []) {
+                    continue;
+                }
+
+                foreach ($containsTypes as $childClass => $slot) {
+                    if ($innerAttribute instanceof $childClass) {
+                        if ($matchingContainer instanceof AttributeInterface) {
+                            throw OpenApiException::fromSource(
+                                sprintf(
+                                    'Ambiguous hierarchy: %s matches multiple containers (%s and %s)',
+                                    $innerAttribute::class,
+                                    $matchingContainer::class,
+                                    $outerAttribute::class,
+                                ),
+                                $innerAttribute->getSourceLocation(),
+                            );
+                        }
+                        $matchingContainer = $outerAttribute;
+                        $matchingSlot = $slot;
+                        break;
+                    }
+                }
+            }
+
+            if ($matchingContainer === null) {
+                throw OpenApiException::fromSource(
+                    sprintf('Orphan attribute: %s has no valid container at enclosing level', $innerAttribute::class),
+                    $innerAttribute->getSourceLocation(),
+                );
+            }
+
+            $this->nestChild($matchingContainer, $innerAttribute, $matchingSlot);
+        }
+
+        foreach ($outer as $attribute) {
+            if (!$attribute->isRoot()) {
+                throw OpenApiException::fromSource(
+                    sprintf('Non-root attribute %s remains after resolution — it should have been absorbed by a container', $attribute::class),
+                    $attribute->getSourceLocation(),
+                );
+            }
+        }
+
+        return $outer;
+    }
+
+    protected function nestChild(AttributeInterface $parent, AttributeInterface $child, string $slot): void
+    {
+        if (str_ends_with($slot, '[]')) {
+            $property = substr($slot, 0, -2);
+            $current = $parent->{$property} ?? [];
+            $current[] = $child;
+            $parent->{$property} = $current;
+        } else {
+            if ($parent->{$slot} instanceof AttributeInterface) {
+                throw OpenApiException::fromSource(
+                    sprintf('Duplicate merge: %s already has a %s in slot "%s"', $parent::class, $parent->{$slot}::class, $slot),
+                    $child->getSourceLocation(),
+                );
+            }
+            $parent->{$slot} = $child;
+        }
+    }
+
+    /**
+     * @return list<AttributeInterface>
+     */
+    protected function readAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        $attributes = $reflector->getAttributes(
+            AttributeInterface::class,
+            \ReflectionAttribute::IS_INSTANCEOF,
+        );
+
+        $result = [];
+        foreach ($attributes as $attribute) {
+            if (!class_exists($attribute->getName())) {
+                continue;
+            }
+
+            try {
+                $instance = $attribute->newInstance();
+            } catch (\Error $e) {
+                throw OpenApiException::fromSource(
+                    sprintf('Failed to instantiate attribute "%s": %s', $attribute->getName(), $e->getMessage()),
+                    SourceLocation::fromReflector($reflector),
+                    $e,
+                );
+            }
+
+            $instance->setReflector($reflector);
+
+            $result[] = $instance;
+        }
+
+        return $result;
+    }
+}

--- a/src/Utils/SourceLocation.php
+++ b/src/Utils/SourceLocation.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+final readonly class SourceLocation implements \Stringable
+{
+    public function __construct(
+        public ?string $filename = null,
+        public ?int $line = null,
+        public ?string $namespace = null,
+        public ?string $class = null,
+        public ?string $method = null,
+        public ?string $property = null,
+        public ?string $parameter = null,
+        public ?string $constant = null,
+    ) {
+    }
+
+    public static function fromReflector(\Reflector $reflector): self
+    {
+        $class = null;
+        $method = null;
+        $property = null;
+        $parameter = null;
+        $constant = null;
+        $filename = null;
+        $line = null;
+        $namespace = null;
+
+        if ($reflector instanceof \ReflectionClass) {
+            $class = $reflector->getName();
+            $namespace = $reflector->getNamespaceName() ?: null;
+            $filename = $reflector->getFileName() ?: null;
+            $line = $reflector->getStartLine() ?: null;
+        } elseif ($reflector instanceof \ReflectionMethod) {
+            $class = $reflector->getDeclaringClass()->getName();
+            $method = $reflector->getName();
+            $namespace = $reflector->getDeclaringClass()->getNamespaceName() ?: null;
+            $filename = $reflector->getFileName() ?: null;
+            $line = $reflector->getStartLine() ?: null;
+        } elseif ($reflector instanceof \ReflectionProperty) {
+            $class = $reflector->getDeclaringClass()->getName();
+            $property = $reflector->getName();
+            $namespace = $reflector->getDeclaringClass()->getNamespaceName() ?: null;
+            $filename = $reflector->getDeclaringClass()->getFileName() ?: null;
+            $line = null;
+        } elseif ($reflector instanceof \ReflectionParameter) {
+            $function = $reflector->getDeclaringFunction();
+            $parameter = $reflector->getName();
+            if ($function instanceof \ReflectionMethod) {
+                $class = $function->getDeclaringClass()->getName();
+                $method = $function->getName();
+                $namespace = $function->getDeclaringClass()->getNamespaceName() ?: null;
+            }
+            $filename = $function->getFileName() ?: null;
+            $line = $function->getStartLine() ?: null;
+        } elseif ($reflector instanceof \ReflectionClassConstant) {
+            $class = $reflector->getDeclaringClass()->getName();
+            $constant = $reflector->getName();
+            $namespace = $reflector->getDeclaringClass()->getNamespaceName() ?: null;
+            $filename = $reflector->getDeclaringClass()->getFileName() ?: null;
+            $line = null;
+        }
+
+        return new self(
+            filename: $filename,
+            line: $line,
+            namespace: $namespace,
+            class: $class,
+            method: $method,
+            property: $property,
+            parameter: $parameter,
+            constant: $constant,
+        );
+    }
+
+    public function __toString(): string
+    {
+        $parts = [];
+
+        if ($this->class !== null) {
+            $parts[] = $this->class;
+        }
+
+        if ($this->method !== null) {
+            $parts[] = ($parts !== [] ? '::' : '') . $this->method . '()';
+        }
+
+        if ($this->property !== null) {
+            $parts[] = ($parts !== [] ? '::$' : '$') . $this->property;
+        }
+
+        if ($this->parameter !== null) {
+            $parts[] = ($parts !== [] ? ' $' : '$') . $this->parameter;
+        }
+
+        if ($this->constant !== null) {
+            $parts[] = ($parts !== [] ? '::' : '') . $this->constant;
+        }
+
+        $location = implode('', $parts);
+
+        if ($this->filename !== null) {
+            $file = $this->filename;
+            if ($this->line !== null) {
+                $file .= ':' . $this->line;
+            }
+            $location = $location ? "{$location} in {$file}" : $file;
+        }
+
+        return $location ?: 'unknown';
+    }
+}

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -1,0 +1,337 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+
+/**
+ * Traversal helpers for walking the Specification tree.
+ */
+class SpecificationWalker
+{
+    /** @var \SplObjectStorage<OA\Schema, true> */
+    private \SplObjectStorage $visited;
+
+    public function __construct(
+        protected readonly Specification $specification,
+    ) {
+    }
+
+    /**
+     * Walk every Schema in the specification, recursively into nested schemas.
+     *
+     * @param callable(OA\Schema): void $visitor
+     */
+    public function eachSchema(callable $visitor): void
+    {
+        $this->walk($visitor, null);
+    }
+
+    /**
+     * Walk every ref-bearing attribute in the specification.
+     *
+     * @param callable(OA\Schema|OA\Parameter|OA\Response|OA\Header|OA\RequestBody|OA\Link|OA\Example|OA\Security\Scheme): void $visitor
+     */
+    public function eachRef(callable $visitor): void
+    {
+        $this->walk(null, $visitor);
+    }
+
+    /**
+     * Single traversal driving both schema and ref visitors.
+     *
+     * @param (callable(OA\Schema): void)|null                                                                                         $schemaVisitor
+     * @param (callable(OA\Schema|OA\Parameter|OA\Response|OA\Header|OA\RequestBody|OA\Link|OA\Example|OA\Security\Scheme): void)|null $refVisitor
+     */
+    protected function walk(?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        $this->visited = new \SplObjectStorage();
+
+        foreach ($this->specification->schemas as $schema) {
+            $this->walkSchemaTree($schema, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->operations as $operation) {
+            $this->walkOperation($operation, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->pathItems as $pathItem) {
+            $this->walkParameters($pathItem->parameters, $schemaVisitor, $refVisitor);
+            $this->walkResponses($pathItem->responses, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->parameters as $parameter) {
+            $this->walkParameter($parameter, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->requestBodies as $body) {
+            if ($refVisitor) {
+                $this->visitRef($body, $refVisitor);
+            }
+            $this->walkMediaTypes($body->content, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->responses as $response) {
+            $this->walkResponse($response, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($this->specification->headers as $header) {
+            $this->walkHeader($header, $schemaVisitor, $refVisitor);
+        }
+
+        if ($refVisitor) {
+            foreach ($this->specification->links as $link) {
+                $this->visitRef($link, $refVisitor);
+            }
+
+            foreach ($this->specification->examples as $example) {
+                $this->visitRef($example, $refVisitor);
+            }
+
+            if ($this->specification->openapi->security) {
+                $this->walkSecurityRefs($this->specification->openapi->security, $refVisitor);
+            }
+        }
+
+        unset($this->visited);
+    }
+
+    protected function walkOperation(OA\Operation $operation, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        $this->walkParameters($operation->parameters, $schemaVisitor, $refVisitor);
+
+        if ($operation->requestBody instanceof OA\RequestBody) {
+            if ($refVisitor) {
+                $this->visitRef($operation->requestBody, $refVisitor);
+            }
+            $this->walkMediaTypes($operation->requestBody->content, $schemaVisitor, $refVisitor);
+        }
+
+        $this->walkResponses($operation->responses, $schemaVisitor, $refVisitor);
+
+        if ($refVisitor && $operation->security) {
+            $this->walkSecurityRefs($operation->security, $refVisitor);
+        }
+
+        if ($operation->callbacks) {
+            foreach ($operation->callbacks as $callback) {
+                if (is_array($callback)) {
+                    array_walk_recursive($callback, function (mixed $value) use ($schemaVisitor, $refVisitor): void {
+                        if ($value instanceof OA\Operation) {
+                            $this->walkOperation($value, $schemaVisitor, $refVisitor);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<OA\Parameter>|null $parameters
+     */
+    protected function walkParameters(?array $parameters, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if (!$parameters) {
+            return;
+        }
+
+        foreach ($parameters as $parameter) {
+            $this->walkParameter($parameter, $schemaVisitor, $refVisitor);
+        }
+    }
+
+    protected function walkParameter(OA\Parameter $parameter, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if ($refVisitor) {
+            $this->visitRef($parameter, $refVisitor);
+            $this->walkExampleRefs($parameter->examples, $refVisitor);
+        }
+        if ($parameter->schema instanceof OA\Schema) {
+            $this->walkSchemaTree($parameter->schema, $schemaVisitor, $refVisitor);
+        }
+    }
+
+    /**
+     * @param list<OA\Response>|null $responses
+     */
+    protected function walkResponses(?array $responses, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if (!$responses) {
+            return;
+        }
+
+        foreach ($responses as $response) {
+            $this->walkResponse($response, $schemaVisitor, $refVisitor);
+        }
+    }
+
+    protected function walkResponse(OA\Response $response, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if ($refVisitor) {
+            $this->visitRef($response, $refVisitor);
+        }
+        $this->walkMediaTypes($response->content, $schemaVisitor, $refVisitor);
+
+        if ($response->headers) {
+            foreach ($response->headers as $header) {
+                $this->walkHeader($header, $schemaVisitor, $refVisitor);
+            }
+        }
+
+        if ($refVisitor && $response->links) {
+            foreach ($response->links as $link) {
+                $this->visitRef($link, $refVisitor);
+            }
+        }
+    }
+
+    protected function walkHeader(OA\Header $header, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if ($refVisitor) {
+            $this->visitRef($header, $refVisitor);
+            $this->walkExampleRefs($header->examples, $refVisitor);
+        }
+        if ($header->schema instanceof OA\Schema) {
+            $this->walkSchemaTree($header->schema, $schemaVisitor, $refVisitor);
+        }
+    }
+
+    /**
+     * @param list<OA\MediaType>|null $mediaTypes
+     */
+    protected function walkMediaTypes(?array $mediaTypes, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if (!$mediaTypes) {
+            return;
+        }
+
+        foreach ($mediaTypes as $mediaType) {
+            if ($mediaType->schema instanceof OA\Schema) {
+                $this->walkSchemaTree($mediaType->schema, $schemaVisitor, $refVisitor);
+            }
+            if ($refVisitor) {
+                $this->walkExampleRefs($mediaType->examples, $refVisitor);
+            }
+        }
+    }
+
+    protected function walkSchemaTree(OA\Schema $schema, ?callable $schemaVisitor, ?callable $refVisitor): void
+    {
+        if ($this->visited->contains($schema)) {
+            return;
+        }
+        $this->visited->attach($schema);
+
+        if ($schemaVisitor) {
+            $schemaVisitor($schema);
+        }
+        if ($refVisitor) {
+            $this->visitRef($schema, $refVisitor);
+            if ($schema->discriminator instanceof OA\Discriminator && $schema->discriminator->mapping !== null) {
+                foreach ($schema->discriminator->mapping as $ref) {
+                    $refVisitor(new OA\Schema(ref: $ref));
+                }
+            }
+        }
+
+        if ($schema->properties) {
+            foreach ($schema->properties as $property) {
+                if ($property instanceof OA\Property && $property->schema instanceof OA\Schema) {
+                    $this->walkSchemaTree($property->schema, $schemaVisitor, $refVisitor);
+                }
+            }
+        }
+
+        if ($schema->items instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->items, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->additionalProperties instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->additionalProperties, $schemaVisitor, $refVisitor);
+        }
+
+        foreach ($schema->allOf ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        foreach ($schema->anyOf ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        foreach ($schema->oneOf ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->not instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->not, $schemaVisitor, $refVisitor);
+        }
+
+        // JSON Schema 2020-12 keywords
+        foreach ($schema->prefixItems ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->contains instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->contains, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->unevaluatedItems instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->unevaluatedItems, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->unevaluatedProperties instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->unevaluatedProperties, $schemaVisitor, $refVisitor);
+        }
+        foreach ($schema->patternProperties ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        foreach ($schema->dependentSchemas ?? [] as $child) {
+            $this->walkSchemaTree($child, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->propertyNames instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->propertyNames, $schemaVisitor, $refVisitor);
+        }
+
+        // Conditional
+        if ($schema->if instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->if, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->then instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->then, $schemaVisitor, $refVisitor);
+        }
+        if ($schema->else instanceof OA\Schema) {
+            $this->walkSchemaTree($schema->else, $schemaVisitor, $refVisitor);
+        }
+    }
+
+    /**
+     * @param list<OA\Example>|null $examples
+     */
+    protected function walkExampleRefs(?array $examples, callable $refVisitor): void
+    {
+        if (!$examples) {
+            return;
+        }
+
+        foreach ($examples as $example) {
+            $this->visitRef($example, $refVisitor);
+        }
+    }
+
+    /**
+     * @param list<OA\Security\Requirement> $security
+     */
+    protected function walkSecurityRefs(array $security, callable $refVisitor): void
+    {
+        foreach ($security as $requirement) {
+            foreach (array_keys($requirement->toArray()) as $schemeName) {
+                $refVisitor(new OA\Security\Scheme(ref: '#/components/securitySchemes/' . $schemeName));
+            }
+        }
+    }
+
+    protected function visitRef(OA\Schema|OA\Parameter|OA\Response|OA\Header|OA\RequestBody|OA\Link|OA\Example|OA\Security\Scheme $attribute, callable $refVisitor): void
+    {
+        if ($attribute->ref !== null) {
+            $refVisitor($attribute);
+        }
+    }
+}

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -243,6 +243,8 @@ class SpecificationWalker
             foreach ($schema->properties as $property) {
                 if ($property instanceof OA\Property && $property->schema instanceof OA\Schema) {
                     $this->walkSchemaTree($property->schema, $schemaVisitor, $refVisitor);
+                } elseif ($property instanceof OA\Schema) {
+                    $this->walkSchemaTree($property, $schemaVisitor, $refVisitor);
                 }
             }
         }

--- a/tests/AssemblerTest.php
+++ b/tests/AssemblerTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Assembler;
+use OpenApi\OpenApiException;
+use PHPUnit\Framework\TestCase;
+
+final class AssemblerTest extends TestCase
+{
+    public function testHierarchyPropertyAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\SimpleProduct::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertEquals('SimpleProduct', $spec->schemas[0]->schema);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(2, $spec->schemas[0]->properties);
+    }
+
+    public function testHierarchyPromotedPropertyAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\PromotedProduct::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(2, $spec->schemas[0]->properties);
+
+        $names = array_map(fn ($p) => $p->property, $spec->schemas[0]->properties);
+        $this->assertContains('quantity', $names);
+        $this->assertContains('brand', $names);
+    }
+
+    public function testHierarchyMethodParametersAbsorbedByOperation(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\SimpleController::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->operations);
+        $this->assertEquals('/products/{product_id}', $spec->operations[0]->path);
+        $this->assertNotNull($spec->operations[0]->parameters);
+        $this->assertCount(1, $spec->operations[0]->parameters);
+        $this->assertEquals('product_id', $spec->operations[0]->parameters[0]->name);
+    }
+
+    public function testClassWithoutRootAttributeSkipped(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanProperty::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(0, $spec->schemas);
+    }
+
+    public function testClassConstantAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\WithConstant::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(1, $spec->schemas[0]->properties);
+        $this->assertEquals('kind', $spec->schemas[0]->properties[0]->property);
+    }
+
+    public function testParameterOnClassWithoutPathItemThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Non-root attribute.*Parameter.*remains after resolution/');
+
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanParameter::class));
+    }
+
+    public function testSecurityRequirementOnClassWithoutPathItemThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Non-root attribute.*Requirement.*remains after resolution/');
+
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanSecurity::class));
+    }
+}

--- a/tests/Fixtures/Assembler/AmbiguousMerge.php
+++ b/tests/Fixtures/Assembler/AmbiguousMerge.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'AmbiguousMerge')]
+class AmbiguousMerge
+{
+    #[OA\Schema(description: 'ambiguous')]
+    #[OA\Property(property: 'first')]
+    #[OA\Property(property: 'second')]
+    public string $value;
+}

--- a/tests/Fixtures/Assembler/OrphanParameter.php
+++ b/tests/Fixtures/Assembler/OrphanParameter.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'integer'))]
+class OrphanParameter
+{
+    #[OA\Operation\Get(path: '/orphan')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function index()
+    {
+    }
+}

--- a/tests/Fixtures/Assembler/OrphanProperty.php
+++ b/tests/Fixtures/Assembler/OrphanProperty.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+class OrphanProperty
+{
+    #[OA\Property(property: 'orphan')]
+    public string $orphan;
+}

--- a/tests/Fixtures/Assembler/OrphanSecurity.php
+++ b/tests/Fixtures/Assembler/OrphanSecurity.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Security\Requirement(scheme: 'bearerAuth')]
+class OrphanSecurity
+{
+    #[OA\Operation\Get(path: '/orphan')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function index()
+    {
+    }
+}

--- a/tests/Fixtures/Assembler/PromotedProduct.php
+++ b/tests/Fixtures/Assembler/PromotedProduct.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'PromotedProduct')]
+class PromotedProduct
+{
+    public function __construct(
+        #[OA\Property(property: 'quantity')]
+        public int $quantity,
+        #[OA\Property(property: 'brand')]
+        #[OA\Schema(example: 'Acme')]
+        public ?string $brand,
+    ) {
+    }
+}

--- a/tests/Fixtures/Assembler/SimpleController.php
+++ b/tests/Fixtures/Assembler/SimpleController.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+class SimpleController
+{
+    #[OA\Operation(path: '/products/{product_id}', method: 'get')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function getProduct(
+        #[OA\Parameter(name: 'product_id', in: 'path', required: true)]
+        #[OA\Schema(format: 'int64')]
+        ?int $product_id,
+    ) {
+    }
+}

--- a/tests/Fixtures/Assembler/SimpleProduct.php
+++ b/tests/Fixtures/Assembler/SimpleProduct.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'SimpleProduct')]
+class SimpleProduct
+{
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(description: 'The name.')]
+    public string $name;
+
+    #[OA\Property(property: 'price')]
+    #[OA\Schema(type: 'number', format: 'float')]
+    public float $price;
+}

--- a/tests/Fixtures/Assembler/WithConstant.php
+++ b/tests/Fixtures/Assembler/WithConstant.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'WithConstant')]
+class WithConstant
+{
+    #[OA\Property(property: 'kind')]
+    public const KIND = 'Virtual';
+}

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\AttributeInterface;
+use OpenApi\OpenApiException;
+use OpenApi\Spec as OA;
+use OpenApi\Tests\Fixtures\Assembler\AmbiguousMerge;
+use OpenApi\Tests\Fixtures\Assembler\SimpleController;
+use OpenApi\Tests\Fixtures\Assembler\SimpleProduct;
+use OpenApi\Utils\AttributeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeFactoryTest extends TestCase
+{
+    public function testFromReflectorProperty(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionProperty(SimpleProduct::class, 'name'));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Property::class, $result[0]);
+        $this->assertSame('name', $result[0]->property);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('The name.', $result[0]->schema->description);
+    }
+
+    public function testFromReflectorParameter(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionParameter(
+            [SimpleController::class, 'getProduct'],
+            'product_id',
+        ));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Parameter::class, $result[0]);
+        $this->assertSame('product_id', $result[0]->name);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('int64', $result[0]->schema->format);
+    }
+
+    public function testFromReflectorAmbiguousMergeThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Ambiguous merge/');
+
+        $factory = new AttributeFactory();
+        $factory->fromReflector(new \ReflectionProperty(AmbiguousMerge::class, 'value'));
+    }
+
+    public function testMembersOfCollectsOwnProperties(): void
+    {
+        $factory = new AttributeFactory();
+        $members = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
+
+        $propertyNames = array_map(
+            fn (AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
+            $members,
+        );
+
+        $this->assertContains('name', $propertyNames);
+    }
+
+    public function testHasAttributesTrue(): void
+    {
+        $factory = new AttributeFactory();
+
+        $this->assertTrue($factory->hasAttributes(new \ReflectionClass(SimpleProduct::class)));
+    }
+
+    public function testHasAttributesFalse(): void
+    {
+        $factory = new AttributeFactory();
+
+        $this->assertFalse($factory->hasAttributes(new \ReflectionClass(\stdClass::class)));
+    }
+
+    public function testResolveHierarchyAbsorbsChildren(): void
+    {
+        $factory = new AttributeFactory();
+
+        $outer = $factory->fromReflector(new \ReflectionClass(SimpleProduct::class));
+        $inner = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
+
+        $roots = $factory->resolveHierarchy($outer, $inner);
+
+        $this->assertCount(1, $roots);
+        $this->assertInstanceOf(OA\Schema::class, $roots[0]);
+        $this->assertNotEmpty($roots[0]->properties);
+    }
+}


### PR DESCRIPTION
## Summary

  Introduces the assembly stage of the spec pipeline — the step that scans PHP classes and collects spec attributes into a `Specification` container.

  Source files → ReflectionClass → Assembler → Specification

  Depends on #2054.

  ## Design

  ### Two-pass assembly

  The Assembler runs two distinct passes per class:

  1. **Sibling merge** — attributes on the same reflector compose via `merge()` maps. E.g., `Schema` merges into `Property` filling its `$schema` slot.
  2. **Hierarchy resolution** — attributes from inner reflectors (properties, methods, parameters, constants) flow up into enclosing-level attributes via `contains()` maps. E.g., `Operation` on
  a method absorbs `Parameter` from its parameters; `Schema` on a class absorbs `Property` from its members.

  After both passes, only root attributes remain and are added to the `Specification`. Non-root attributes that survive resolution trigger an error (orphan detection).

  ### AttributeFactory

  Extracted helper that encapsulates:
  - Reading PHP 8.1+ attributes from reflectors
  - Sibling composition via `merge()` slot maps (same-reflector nesting)
  - Hierarchical absorption via `contains()` slot maps (inner → outer)

  Shared between the Assembler and future augmenter pipes that need to manufacture spec objects from reflection (e.g. `ExpandHierarchy` for non-schema ancestor members).

  ### Slot semantics

  The `merge()` and `contains()` maps return `[TargetClass => 'slotName']`:
  - `'parameters[]'` — collection append
  - `'requestBody'` — scalar assignment

  This eliminates the implicit `$_nested` arrays and reflection-heavy nesting logic from the classic pipeline.

  ### Orphan detection

  After hierarchy resolution, any remaining non-root attribute is an error — e.g. a `Parameter` on a class without a `PathItem` or `Operation` to absorb it. The Assembler throws
  `OpenApiException` with source location context.

